### PR TITLE
feat(auth): add toast message to create account

### DIFF
--- a/frontend/components/forms/OTPForm.tsx
+++ b/frontend/components/forms/OTPForm.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from "../ui/button";
 import { useRouter } from "next/navigation";
 import { usePathname } from "next/navigation";
+import { toast } from "sonner";
 
 const formSchema = z.object({
   otp: z.string().min(1,{message: "Validation code is required."}).min(6, { message: "OTP must be 6 digits" })
@@ -38,7 +39,16 @@ export function OTPForm() {
     console.log(values)
     
     if(pathname === "/auth/create-account/email-validation") {
+      toast('Success',{
+        description: 'Your account has been successfully created!',
+        duration:2000,
+        style:{
+          borderLeft: '4px solid #0CAC42',
+          fontSize: '14px',
+        }
+      })
       router.push("/dashboard");
+
     } else {
       router.push("/auth/forgot-password/reset-password");
     }

--- a/frontend/components/forms/ResetPasswordForm.tsx
+++ b/frontend/components/forms/ResetPasswordForm.tsx
@@ -60,7 +60,6 @@ export default function ResetPasswordForm() {
         description: 'Your password has been changes successfully.',
         duration:2000,
         style:{
-          width: '80%',
           borderLeft: '4px solid #0CAC42',
           fontSize: '14px',
         }


### PR DESCRIPTION
- Add a toast notification to the create account screen to inform users of successful registration. 
- Bug fixes a styling issue affecting toast messages on the reset password screen.